### PR TITLE
.gitignore: remove Cargo.lock entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /dist/
 /target/
-/Cargo.lock


### PR DESCRIPTION
This repo is a template for building apps (or to phrase it another way: products that are at the end of the dependency chain - as opposed to libs). https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html states that for products that are at the end of the dependency chain, Cargo.lock should be checked into version control.