### PR TITLE
Fix bug in template

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8" />
     <title>Trunk Template</title>
     <link data-trunk rel="sass" href="index.scss" />
+    <link data-trunk rel="rust"/>
   </head>
 </html>


### PR DESCRIPTION
When this code has been checked out. 
`trunk build` fails with following error: "Document has neither a <link data-trunk rel="rust"/> nor a <body>. Either one must be present."

When the `<link data-trunk rel="rust"/>` snippet is added, the code will build successfully. 

Without this fix, the getting started guide of yew will fail with an error.