### PR TITLE
fix: add required body element

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,4 +5,5 @@
     <title>Trunk Template</title>
     <link data-trunk rel="sass" href="index.scss" />
   </head>
+  <body></body>
 </html>


### PR DESCRIPTION
Trunk 0.21.x requires either a link or body element: https://github.com/trunk-rs/trunk/blob/main/src/pipelines/rust/output.rs#L99-L104

This adds an empty body, which shouldn't hurt in any case.